### PR TITLE
- fix#9: Add chunk size to manifest and ignore in sync From

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-export const VERSION = 's3fsync - version 0.3.0 - 20240427'
+export const VERSION = 's3fsync - version 0.4.0 - 20240428'
 export const MIN_CHUNK_SIZE = 4096

--- a/helper.js
+++ b/helper.js
@@ -44,8 +44,8 @@ export const mergeManifests = (inLocalManifest, inS3Manifest) => {
     // mergedLocalManifest chunks need to be uploaded
     // mergedS3Manifest chunks need to be removed
     return {
-        mergedLocalManifest: inLocalManifest.filter(chunk => !hasSameHash(chunk, inS3Manifest)),
-        mergedS3Manifest: inS3Manifest.filter(chunk => indexOfChunk(chunk, inLocalManifest) == -1)
+        mergedLocalManifest: inLocalManifest.chunks.filter(chunk => !hasSameHash(chunk, inS3Manifest.chunks)),
+        mergedS3Manifest: inS3Manifest.chunks.filter(chunk => indexOfChunk(chunk, inLocalManifest.chunks) == -1)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3rsync",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A simple yet useful rsync alike tool for S3",
   "main": "bin/index.js",
   "type": "module",


### PR DESCRIPTION
- chunksize (-cs) is ignored in syncFrom to avoid downloading unnecessary chunks